### PR TITLE
datetime error

### DIFF
--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -20,6 +20,10 @@ Devise.setup do |config|
   # :mongoid (bson_ext recommended) by default. Other ORMs may be
   # available as additional gems.
   require 'devise/orm/active_record'
+  
+  
+  #add this to use Date_time from activesuport library ---kimia
+  require 'active_support/core_ext'
 
   # ==> Configuration for any authentication mechanism
   # Configure which keys are used when authenticating a user. The default is


### PR DESCRIPTION
to_datetime is a method from rails' activesupport library and sidekiq worker is not using this.

try adding require 'active_support/core_ext' to read datetime from active support library.